### PR TITLE
BugFix : Will fail for a selection of doubles

### DIFF
--- a/RyuCsharp/d2s_intrinsics.cs
+++ b/RyuCsharp/d2s_intrinsics.cs
@@ -41,7 +41,7 @@ namespace RyuCsharp
         {
             // We don't need to handle the case dist >= 64 here (see above).
             assert(dist < 64);
-            assert(dist > 0);
+            if (dist == 0) return lo;
             return (hi << (int)(64 - dist)) | (lo >> (int)dist);
         }
 


### PR DESCRIPTION
d2exp_buffered_n(5737722933969577e-231, 19, buffer)  vs .ToString("G19")  for example